### PR TITLE
CODEML: Fixing of Ete3 installation occurs within the pipeline now

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains `Nextflow` implementations of common workflows used by
 the Sanders research group. The current workflows I am looking to implement are:
 
 * [x] QC pipeline
-* [x] Stacks (v2) pipeline
+* [x] Stacks 2 pipeline
 * [x] CodeML
 * [x] Consensus calling
 * [x] Transcriptome assembly pipeline
@@ -32,7 +32,6 @@ Below are the install instructions for
 - Nextflow
 - Sanders-workflow pipeline
 - Conda setup
-- CodeML specific set up
 
 ### Nextflow install
 Use the following command to install the Nextflow executable to **your** Phoenix
@@ -114,59 +113,6 @@ channels:
 ```
 
 If this information is there, then you are good to go.
-
-## CodeML specific set up
-
-Unfortunately the `ete-evol` conda installation doesn't actually work. The developers
-are aware of this, and have implemented a fix through their github version, but this
-doesn't help us.
-
-#### These steps are REQUIRED to be able to use the CodeML sub-workflow
-
-First, if you haven't already, visit the UofA Conda set up guide linked above
-to ensure your package and environment paths are configured correctly.
-
-Once you're confident that Conda has been configured correctly, run the following:
-
-```{shell}
-module load Anaconda3
-
-## Create pipelines directory if it doesn't already exist
-mkdir -pv $FASTDIR/pipelines
-
-## Create conda environment with specified prefix path
-conda create --prefix=$FASTDIR/pipelines/ETE_env -c etetoolkit ete3 ete_toolchain python numpy PyQt lxml
-
-## Install GitHub version of Ete-Evol
-cd $FASTDIR/pipelines
-git clone https://github.com/etetoolkit/ete.git
-
-## Change into the software directory
-cd ete
-
-## Activate the conda environment
-conda activate $FASTDIR/pipelines/ETE_env
-
-## Run the install script
-python setup.py install
-
-## Check the installation
-ete3 build check
-
-## Deactivate the environment
-conda deactivate
-```
-
-If the `ete3 build check` command comes back with `OK` for everything then the install
-was successful.
-
-The path `$FASTDIR/pipelines/ETE_env` will be a required argument to the `codeml_pipeline`
-sub-workflow. This pipeline will use this conda environment to carry out the analyses
-rather than downloading the software on the fly, which is how every other sub-workflow
-operates.
-
-This is less than ideal, but I have created an issue with the developers of `Ete` and will
-hopefully hear back soon.
 
 ## Pipeline specifics
 

--- a/conf/slurm.config
+++ b/conf/slurm.config
@@ -3,7 +3,6 @@ params {
     max_cpus = 32
     max_mem = 120.Gb
     max_time = 72.h
-    conda_env_path = false
 }
 
 // Process parameters
@@ -21,7 +20,7 @@ process {
   maxRetries = 3
   maxErrors = '-1' // Turn off maxErrors
 
-  conda = 'fastp fastqc stacks=2.52 samtools bcftools blast hmmer trinity transdecoder cd-hit bwa-mem2 gatk4'
+  conda = 'fastp fastqc stacks=2.52 samtools bcftools blast hmmer trinity transdecoder cd-hit bwa-mem2 gatk4 ete3 ete_toolchain'
 
   // conda = workflow.projectDir + '/environment.yaml' // What I want...
 
@@ -46,10 +45,6 @@ process {
     time = { check_resources(params.codeml_time * task.attempt, params.max_time) }
     cpus = { params.codeml_threads }
     memory = { check_resources( params.codeml_memory * task.attempt, params.max_mem) }
-
-    if(params.conda_env_path) {
-      conda = params.conda_env_path
-    }
   }
 
   withLabel:index {

--- a/lib/modules/codeml_pipeline/processes.nf
+++ b/lib/modules/codeml_pipeline/processes.nf
@@ -1,3 +1,22 @@
+process setup_ete {
+    tag { 'Installing ETE-EVOL' }
+
+    input:
+        val wf
+    
+    when:
+        wf.contains('codeml_pipeline')
+    
+    script:
+        """
+        mkdir -p \${FASTDIR}/pipelines
+        cd \${FASTDIR}/pipelines
+        git clone https://github.com/etetoolkit/ete.git
+        cd ete
+        python setup.py install
+        """
+}
+
 process run_codeml {
     tag { id }
 
@@ -6,6 +25,7 @@ process run_codeml {
     label 'codeml'
 
     input:
+        val setup
         tuple id, file(seqs), tree, mark
         val outdir
         val models

--- a/lib/modules/codeml_pipeline/workflows.nf
+++ b/lib/modules/codeml_pipeline/workflows.nf
@@ -1,4 +1,4 @@
-include {run_codeml} from './processes'
+include {setup_ete; run_codeml} from './processes'
 
 workflow codeml_pipeline {
     take: seqs_tree_mark
@@ -6,7 +6,18 @@ workflow codeml_pipeline {
 
     main:
 
-    run_codeml(seqs_tree_mark,
+    // Configure ete evol to work
+    File path = new File("${FASTDIR}/pipelines/ete")
+    if(!path.isDirectory()) {
+        setup_ete(workflow)
+        Channel.value('placeholder').set { setup }
+    } else {
+        Channel.value('placeholder').set { setup }
+    }
+
+    // Run ete-evol
+    run_codeml(setup,
+               seqs_tree_mark,
                params.outdir,
                params.models,
                params.tests,

--- a/lib/params_parser.nf
+++ b/lib/params_parser.nf
@@ -235,7 +235,6 @@ def empty_args_codeml_map() {
     args.leaves = false
     args.internals = false
     args.codeml_param = false
-    args.conda_env_path = false
 
     // Resource arguments
     args.codeml_threads = false
@@ -282,25 +281,6 @@ def check_args_codeml(Map args, Map mainArgs) {
     if(args.sub_workflows.contains('codeml_pipeline') ){
 
         codeml_args.codeml_param = args.codeml_param ?: false
-
-        // Pre-built conda path
-        if(args.conda_env_path) {
-            
-            try {
-                File file = new File(args.conda_env_path)
-                assert file.exists()
-            } catch(AssertionError e) {
-                println("ERROR: Pre-built conda environment for CodeML doesn't exist " + 
-                args.conda_env_path + "\nError message: " + e.getMessage())
-                System.exit(1)
-            }
-    
-            codeml_args.conda_env_path = args.conda_env_path
-    
-        } else {
-            println("ERROR: No supplied argument to '--conda_env_path'")
-            System.exit(1)
-        }
         
         // Have tree files been provided
         if(!trees){


### PR DESCRIPTION
Ete3 conda installation doesn't work out of the box. The github version of the code needs to be downloaded and installed within the conda environment to function properly. 

This pull request integrates the downloading and installation of the github ete3 software into the pipeline. Users no longer need to pre-install the software in a custom conda environment, providing the path to the pipeline.